### PR TITLE
Upgrading phpstan & infection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,14 +11,14 @@
     "require-dev": {
         "ciaranmcnulty/phpspec-typehintedmethods": "^3.0",
         "friendsofphp/php-cs-fixer": "^2.10",
-        "infection/infection": "^0.8.1",
+        "infection/infection": "^0.9@dev",
         "leanphp/phpspec-code-coverage": "^4.0",
         "mockery/mockery": "^1.0",
         "phing/phing": "^2.16",
         "phpmd/phpmd": "^2.6",
         "phpspec/phpspec": "^4.2",
-        "phpstan/phpstan": "^0.9.0",
-        "phpstan/phpstan-phpunit": "^0.9.0",
+        "phpstan/phpstan": "^0.10.0",
+        "phpstan/phpstan-phpunit": "^0.10.0",
         "phpunit/phpunit": "^7.0",
         "slevomat/coding-standard": "^4.0",
         "squizlabs/php_codesniffer": "^3.1"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,7 @@
 parameters:
 	bootstrap: tests/bootstrap.php
 	ignoreErrors:
+	    - '#Parameter \#1 \$json of function json_decode expects string, string|false given.#'
 	includes:
 	    - vendor/phpstan/phpstan-phpunit/extension.neon
 	    - vendor/phpstan/phpstan-phpunit/rules.neon

--- a/src/Commit/CommitDate.php
+++ b/src/Commit/CommitDate.php
@@ -6,6 +6,7 @@ namespace DevboardLib\Git\Commit;
 
 use DateTime;
 use Git\Commit\CommitDate as CommitDateInterface;
+use RuntimeException;
 
 /**
  * @see \spec\DevboardLib\Git\Commit\CommitDateSpec
@@ -21,6 +22,10 @@ class CommitDate extends DateTime implements CommitDateInterface
     public static function createFromFormat($format, $time, $object = null): self
     {
         $date = parent::createFromFormat($format, $time, $object);
+
+        if (false === $date) {
+            throw new RuntimeException('Unparsable date/time');
+        }
 
         return new self($date->format('c'));
     }


### PR DESCRIPTION
Phpstan 0.10 is out and since it uses nikic/php-parser 4.x, we need to upgrade infection to 0.9 dev version too.