### PR TITLE
Add `->asString()` and deprecate `__toString()`

### DIFF
--- a/spec/Branch/BranchNameSpec.php
+++ b/spec/Branch/BranchNameSpec.php
@@ -33,6 +33,7 @@ class BranchNameSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
+        $this->asString()->shouldReturn('master');
         $this->__toString()->shouldReturn('master');
     }
 

--- a/spec/Commit/Author/AuthorNameSpec.php
+++ b/spec/Commit/Author/AuthorNameSpec.php
@@ -33,6 +33,7 @@ class AuthorNameSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
+        $this->asString()->shouldReturn('John Smith');
         $this->__toString()->shouldReturn('John Smith');
     }
 

--- a/spec/Commit/CommitDateSpec.php
+++ b/spec/Commit/CommitDateSpec.php
@@ -26,11 +26,13 @@ class CommitDateSpec extends ObjectBehavior
     public function it_can_be_created_from_custom_format()
     {
         $result = $this->createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
+        $result->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
         $result->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 
     public function it_is_castable_to_string()
     {
+        $this->asString()->shouldReturn('2018-01-01T11:22:33+00:00');
         $this->__toString()->shouldReturn('2018-01-01T11:22:33+00:00');
     }
 

--- a/spec/Commit/CommitMessageSpec.php
+++ b/spec/Commit/CommitMessageSpec.php
@@ -33,6 +33,7 @@ class CommitMessageSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
+        $this->asString()->shouldReturn('A commit message');
         $this->__toString()->shouldReturn('A commit message');
     }
 

--- a/spec/Commit/CommitShaSpec.php
+++ b/spec/Commit/CommitShaSpec.php
@@ -33,6 +33,7 @@ class CommitShaSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
+        $this->asString()->shouldReturn('e54c3c97b4024b4a9b270b62921c6b830d780bd3');
         $this->__toString()->shouldReturn('e54c3c97b4024b4a9b270b62921c6b830d780bd3');
     }
 

--- a/spec/Commit/Committer/CommitterNameSpec.php
+++ b/spec/Commit/Committer/CommitterNameSpec.php
@@ -33,6 +33,7 @@ class CommitterNameSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
+        $this->asString()->shouldReturn('John Smith');
         $this->__toString()->shouldReturn('John Smith');
     }
 

--- a/spec/Tag/TagNameSpec.php
+++ b/spec/Tag/TagNameSpec.php
@@ -33,6 +33,7 @@ class TagNameSpec extends ObjectBehavior
 
     public function it_is_castable_to_string()
     {
+        $this->asString()->shouldReturn('0.1');
         $this->__toString()->shouldReturn('0.1');
     }
 

--- a/src/Branch/BranchName.php
+++ b/src/Branch/BranchName.php
@@ -32,6 +32,14 @@ class BranchName implements ReferenceName
         return $this->name;
     }
 
+    public function asString(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @deprecated Lets use `asString()`
+     */
     public function __toString(): string
     {
         return $this->name;

--- a/src/Commit/Author/AuthorName.php
+++ b/src/Commit/Author/AuthorName.php
@@ -30,6 +30,14 @@ class AuthorName implements AuthorNameInterface
         return $this->name;
     }
 
+    public function asString(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @deprecated Lets use `asString()`
+     */
     public function __toString(): string
     {
         return $this->name;

--- a/src/Commit/CommitDate.php
+++ b/src/Commit/CommitDate.php
@@ -14,6 +14,14 @@ use RuntimeException;
  */
 class CommitDate extends DateTime implements CommitDateInterface
 {
+    public function asString(): string
+    {
+        return $this->format('c');
+    }
+
+    /**
+     * @deprecated Lets use `asString()`
+     */
     public function __toString(): string
     {
         return $this->format('c');
@@ -32,7 +40,7 @@ class CommitDate extends DateTime implements CommitDateInterface
 
     public function serialize(): string
     {
-        return $this->__toString();
+        return $this->asString();
     }
 
     public static function deserialize($value): self

--- a/src/Commit/CommitMessage.php
+++ b/src/Commit/CommitMessage.php
@@ -30,6 +30,14 @@ class CommitMessage implements CommitMessageInterface
         return $this->message;
     }
 
+    public function asString(): string
+    {
+        return $this->message;
+    }
+
+    /**
+     * @deprecated Lets use `asString()`
+     */
     public function __toString(): string
     {
         return $this->message;

--- a/src/Commit/CommitSha.php
+++ b/src/Commit/CommitSha.php
@@ -30,6 +30,14 @@ class CommitSha implements CommitShaInterface
         return $this->sha;
     }
 
+    public function asString(): string
+    {
+        return $this->sha;
+    }
+
+    /**
+     * @deprecated Lets use `asString()`
+     */
     public function __toString(): string
     {
         return $this->sha;

--- a/src/Commit/Committer/CommitterName.php
+++ b/src/Commit/Committer/CommitterName.php
@@ -30,6 +30,14 @@ class CommitterName implements CommitterNameInterface
         return $this->name;
     }
 
+    public function asString(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @deprecated Lets use `asString()`
+     */
     public function __toString(): string
     {
         return $this->name;

--- a/src/Tag/TagName.php
+++ b/src/Tag/TagName.php
@@ -32,6 +32,14 @@ class TagName implements ReferenceName
         return $this->name;
     }
 
+    public function asString(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @deprecated Lets use `asString()`
+     */
     public function __toString(): string
     {
         return $this->name;

--- a/tests/Branch/BranchNameTest.php
+++ b/tests/Branch/BranchNameTest.php
@@ -37,6 +37,7 @@ class BranchNameTest extends TestCase
 
     public function testToString(): void
     {
+        self::assertSame($this->name, $this->sut->asString());
         self::assertSame($this->name, $this->sut->__toString());
     }
 

--- a/tests/Commit/Author/AuthorNameTest.php
+++ b/tests/Commit/Author/AuthorNameTest.php
@@ -37,6 +37,7 @@ class AuthorNameTest extends TestCase
 
     public function testToString(): void
     {
+        self::assertSame($this->name, $this->sut->asString());
         self::assertSame($this->name, $this->sut->__toString());
     }
 

--- a/tests/Commit/CommitDateTest.php
+++ b/tests/Commit/CommitDateTest.php
@@ -25,11 +25,13 @@ class CommitDateTest extends TestCase
     public function testCreateFromFormat(): void
     {
         $result = $this->sut::createFromFormat(DateTime::ATOM, '2018-01-01T11:22:33Z');
+        self::assertEquals('2018-01-01T11:22:33+00:00', $result->asString());
         self::assertEquals('2018-01-01T11:22:33+00:00', $result->__toString());
     }
 
     public function testToString(): void
     {
+        self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->asString());
         self::assertSame('2018-01-01T11:22:33+00:00', $this->sut->__toString());
     }
 

--- a/tests/Commit/CommitMessageTest.php
+++ b/tests/Commit/CommitMessageTest.php
@@ -37,6 +37,7 @@ class CommitMessageTest extends TestCase
 
     public function testToString(): void
     {
+        self::assertSame($this->message, $this->sut->asString());
         self::assertSame($this->message, $this->sut->__toString());
     }
 

--- a/tests/Commit/CommitShaTest.php
+++ b/tests/Commit/CommitShaTest.php
@@ -37,6 +37,7 @@ class CommitShaTest extends TestCase
 
     public function testToString(): void
     {
+        self::assertSame($this->sha, $this->sut->asString());
         self::assertSame($this->sha, $this->sut->__toString());
     }
 

--- a/tests/Commit/Committer/CommitterNameTest.php
+++ b/tests/Commit/Committer/CommitterNameTest.php
@@ -37,6 +37,7 @@ class CommitterNameTest extends TestCase
 
     public function testToString(): void
     {
+        self::assertSame($this->name, $this->sut->asString());
         self::assertSame($this->name, $this->sut->__toString());
     }
 

--- a/tests/Tag/TagNameTest.php
+++ b/tests/Tag/TagNameTest.php
@@ -37,6 +37,7 @@ class TagNameTest extends TestCase
 
     public function testToString(): void
     {
+        self::assertSame($this->name, $this->sut->asString());
         self::assertSame($this->name, $this->sut->__toString());
     }
 


### PR DESCRIPTION
We should really not be using magic `__toString()`